### PR TITLE
Switching to docker when testing container-build

### DIFF
--- a/.github/workflows/check-container-builder.yml
+++ b/.github/workflows/check-container-builder.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: make test
+      - run: |
+          cd container-builder
+          make test
 
   integration-tests:
     needs: unit-tests
@@ -54,16 +56,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libbtrfs-dev libgpgme-dev libdevmapper-dev
-          version: 1.0
-      - name: Install Podman 4.3.1
         run: |
-          wget http://security.ubuntu.com/ubuntu/pool/main/s/shadow/libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
-          sudo dpkg -i libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
-          wget http://ftp.us.debian.org/debian/pool/main/libp/libpod/podman_4.4.0+ds1-1_amd64.deb
-          sudo dpkg -i podman_4.4.0+ds1-1_amd64.deb
+          sudo apt-get -y install \
+          libgpgme-dev \
+          libbtrfs-dev \
+          libdevmapper-dev
       - name: Setup golang
         uses: actions/setup-go@v2
         with:
@@ -72,20 +69,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Display Podman info
-        run: podman info
-      - name: Start Podman socket
-        run: |
-          systemctl --user start podman.socket
-          systemctl --user status podman.socket
       - name: Run integration tests
         run: |
-          mkdir -p ~/.config/systemd/user/podman.service.d/
-          printf "[Service]\nExecStart=\nExecStart=/usr/bin/podman $LOGGING system service -t 0\nDelegate=true\nType=exec\nKillMode=process\nEnvironment=LOGGING="--log-level=info"\n" > ~/.config/systemd/user/podman.service.d/override.conf
-          systemctl --user daemon-reload
-          systemctl --user start podman.service
-          pid=$(systemctl --user show podman.service  | grep ^MainPID | sed -e 's|MainPID=||')
-          sudo prlimit --pid $pid --nofile=262144:262144
-          sudo prlimit --pid $$ --nofile=262144:262144
           cd container-builder
           make ${{ matrix.container-engine }}-integration-test


### PR DESCRIPTION
We don't need to install podman manually but use docker instead since the runner already has it installed and configured. 