### PR TITLE
[1.44.2.x-prod][SRVLOGIC-185] Change builder configMap default name

### DIFF
--- a/controllers/builder/config.go
+++ b/controllers/builder/config.go
@@ -32,7 +32,7 @@ import (
 const (
 	envVarPodNamespaceName = "POD_NAMESPACE"
 	// ConfigMapName is the default name for the Builder ConfigMap name
-	ConfigMapName                       = "sonataflow-operator-builder-config"
+	ConfigMapName                       = "logic-operator-rhel8-builder-config"
 	configKeyDefaultExtension           = "DEFAULT_WORKFLOW_EXTENSION"
 	configKeyDefaultBuilderResourceName = "DEFAULT_BUILDER_RESOURCE_NAME"
 )

--- a/controllers/workflowdef/image.go
+++ b/controllers/workflowdef/image.go
@@ -23,8 +23,8 @@ import (
 const (
 	latestImageTag              = "latest"
 	nightlySuffix               = "nightly"
-	defaultWorkflowDevModeImage = "quay.io/kiegroup/kogito-swf-devmode"
-	defaultWorkflowBuilderImage = "quay.io/kiegroup/kogito-swf-builder"
+	defaultWorkflowDevModeImage = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-devmode-rhel8"
+	defaultWorkflowBuilderImage = "registry.redhat.io/openshift-serverless-1-tech-preview/logic-swf-builder-rhel8"
 )
 
 // GetWorkflowAppImageNameTag retrieve the tag for the image based on the Workflow based annotation, <workflowid>:latest otherwise

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -48,11 +48,11 @@ const (
 	sonataFlowPlatformYamlCR                  = "sonataflow.org_v1alpha08_sonataflowplatform.yaml"
 	sonataFlowPlatformWithCacheMinikubeYamlCR = "sonataflow.org_v1alpha08_sonataflowplatform_withCache_minikube.yaml"
 	sonataFlowPlatformForOpenshift            = "sonataflow.org_v1alpha08_sonataflowplatform_openshift.yaml"
-	sonataFlowBuilderConfig                   = "sonataflow-operator-builder-config_v1_configmap.yaml"
+	sonataFlowBuilderConfig                   = "logic-operator-rhel8-builder-config_v1_configmap.yaml"
 	sonataFlowBuildSucceed                    = "sonataflow.org_v1alpha08_sonataflowbuild.yaml"
 
 	e2eSamples    = "test/testdata/"
-	manifestsPath = "bundle/manifests/"
+	manifestsPath = "bundle.osl/manifests/"
 )
 
 var projectDir = ""

--- a/version/version.go
+++ b/version/version.go
@@ -20,11 +20,11 @@ import (
 
 const (
 	// Current version
-	OperatorVersion = "2.0.0-snapshot"
+	OperatorVersion = "1.31"
 
 	// Should not be changed
 	snapshotSuffix = "snapshot"
-	latestVersion  = "2.0.0-snapshot"
+	latestVersion  = "1.31"
 )
 
 func IsSnapshot() bool {


### PR DESCRIPTION
**Description of the change:**
Change to reflect productized names in the codebase.

**Motivation for the change:**
See https://issues.redhat.com/browse/SRVLOGIC-185

**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>